### PR TITLE
Document v7.x differences in VisualRWKV READMEs

### DIFF
--- a/VisualRWKV-v7/v7.00/README.md
+++ b/VisualRWKV-v7/v7.00/README.md
@@ -7,3 +7,7 @@ VisualRWKV-MultiImage: Support multiple images in VisualRWKV.
 - Data format is changed. Now it is different from the LLaVA format. So LLaVA can not be directly used in this version.
 - Image feature insertion logic is changed. Now it can support any number of images.
 - Therefore, this version can support multiple images from single image splits, multi-images and video frames.
+
+## 版本差异（v7.00）
+- 使用自定义的 `SamDinoSigLIPViTBackbone` 视觉骨干，并在数据管线中同时处理 dino/sam/siglip 三路图像输入，配套 `multi_image_collate_fn` 合并多图特征。相比后续版本的单一 SigLIP/torchvision 预处理方式更重。  
+- `encode_images` 支持 mini-batch 方式提取图像特征并清理缓存，面向显存压力较大的场景。  

--- a/VisualRWKV-v7/v7.01/README.md
+++ b/VisualRWKV-v7/v7.01/README.md
@@ -7,3 +7,8 @@ VisualRWKV-MultiImage: Support multiple images in VisualRWKV.
 - Data format is changed. Now it is different from the LLaVA format. So LLaVA can not be directly used in this version.
 - Image feature insertion logic is changed. Now it can support any number of images.
 - Therefore, this version can support multiple images from single image splits, multi-images and video frames.
+
+## 版本差异（v7.01）
+- 视觉骨干改为 `transformers.SiglipVisionModel`，并统一使用 `MLPWithContextGating` 投影，去掉了 v7.00 的 `SamDinoSigLIPViTBackbone` 组合式特征。  
+- 数据读取支持 `.json/.jsonl`，并引入可重复的随机打乱（`sample_idx_mapping`）；文本样本会自动注入一个 dummy image token。  
+- 图像预处理简化为单张图的 `AutoImageProcessor` 输出，缺图时回退到零张量；`sample_id` 统一转为字符串。  

--- a/VisualRWKV-v7/v7.02/README.md
+++ b/VisualRWKV-v7/v7.02/README.md
@@ -7,3 +7,8 @@ VisualRWKV-MultiImage: Support multiple images in VisualRWKV.
 - Data format is changed. Now it is different from the LLaVA format. So LLaVA can not be directly used in this version.
 - Image feature insertion logic is changed. Now it can support any number of images.
 - Therefore, this version can support multiple images from single image splits, multi-images and video frames.
+
+## 版本差异（v7.02）
+- 引入 `image_to_regions` 将单图切分为多个 region，并把 image token 数量扩展为 region 数；纯文本样本不再添加 dummy image token。  
+- `multi_image_collate_fn` 回归并将图像拼成扁平的 `(BN, C, H, W)`，训练 dataloader 显式使用该 collate_fn。  
+- `encode_images` 简化为直接处理扁平 batch，不再依赖 `(B, N, ...)` 的 reshape。  

--- a/VisualRWKV-v7/v7.03/README.md
+++ b/VisualRWKV-v7/v7.03/README.md
@@ -7,3 +7,8 @@ VisualRWKV-MultiImage: Support multiple images in VisualRWKV.
 - Data format is changed. Now it is different from the LLaVA format. So LLaVA can not be directly used in this version.
 - Image feature insertion logic is changed. Now it can support any number of images.
 - Therefore, this version can support multiple images from single image splits, multi-images and video frames.
+
+## 版本差异（v7.03）
+- 新增 Visual Token Compressor（VTC），提供 `n_vtc_layer` 与 `compress_visual_tokens`，默认 `num_token_per_image=1024`，并支持从 RWKV block 初始化 VTC 权重。  
+- 图像编码支持每样本不同 tile 数量的右对齐 padding；`multi_image_collate_fn` 传回 `images` 列表与 `tile_counts`。  
+- `select_best_resolution` 默认策略改为 `closest`；新增 `process_pdfs_to_md.py` 与 `scripts/train/test.sh`。  

--- a/VisualRWKV-v7/v7.04/README.md
+++ b/VisualRWKV-v7/v7.04/README.md
@@ -7,3 +7,8 @@ VisualRWKV-MultiImage: Support multiple images in VisualRWKV.
 - Data format is changed. Now it is different from the LLaVA format. So LLaVA can not be directly used in this version.
 - Image feature insertion logic is changed. Now it can support any number of images.
 - Therefore, this version can support multiple images from single image splits, multi-images and video frames.
+
+## 版本差异（v7.04）
+- `multi_image_collate_fn` 改回固定形状 `(B, N, C, H, W)`，并恢复按 region 数量填充 image token。  
+- `encode_images` 回到 `(B, N, L, D)` 处理路径，`compress_visual_tokens` 以 N 维聚合，损失计算也回到 v7.02 风格。  
+- `num_token_per_image` 默认值调回 256；脚本侧做了清理（保留 `diff_stem_delete_common.py`、`rename.sh`，移除多余数据处理脚本）。  

--- a/VisualRWKV-v7/v7.10/README.md
+++ b/VisualRWKV-v7/v7.10/README.md
@@ -7,3 +7,8 @@ VisualRWKV-MultiImage: Support multiple images in VisualRWKV.
 - Data format is changed. Now it is different from the LLaVA format. So LLaVA can not be directly used in this version.
 - Image feature insertion logic is changed. Now it can support any number of images.
 - Therefore, this version can support multiple images from single image splits, multi-images and video frames.
+
+## 版本差异（v7.10）
+- 视觉侧切回 `SamDinoSigLIPViTBackbone`，并引入带 mask 的 `Block` 与新的 `VRWKV/VBlock` 结构，用于视觉预训练/分类分支（含 ImageNet head）。  
+- 训练/评估管线改为基于 `patch_size` 与 `image_size` 计算视觉 token 数，图像预处理使用 torchvision transforms；新增 `enable_pretrain_mode` 与 ImageNet 训练/评估脚本。  
+- 数据集支持多图列表与 `num_image_per_sample`，并携带 `class_id`（`cls_labels`）用于分类任务；工具函数回归固定 `POSSIBLE_RESOLUTIONS` 的 tile 切分策略。  


### PR DESCRIPTION
### Motivation
- Make it easier to understand how v7 releases differ by documenting per-release changes in the repository. 
- Capture breaking/data-format and architecture changes across `v7.00` → `v7.10` so users can pick the right branch. 
- Provide quick references for differences in vision backbone, data pipeline, and training/evaluation behaviour. 

### Description
- Added per-version summary sections to `VisualRWKV-v7/v7.00/README.md`, `v7.01/README.md`, `v7.02/README.md`, `v7.03/README.md`, `v7.04/README.md`, and `v7.10/README.md` describing notable changes. 
- Documented vision backbone evolution (e.g. `SamDinoSigLIPViTBackbone` → `SiglipVisionModel` → back to Sam/Dino+SigLIP), projection/encoder changes, and pretrain/classification branches. 
- Documented data pipeline and token handling differences such as `.json/.jsonl` loading, dummy image token injection, `image_to_regions` tiling, `multi_image_collate_fn` shape changes, and `num_token_per_image` defaults. 
- Noted training/eval pipeline updates including `patch_size`/`image_size` tokenization, VTC/VRWKV components, and added scripts for ImageNet/eval where applicable. 

### Testing
- No automated tests were run because this is a documentation-only change. 
- Local repository file updates were staged and committed successfully (informational only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b1bc2324832db89bd79aa79a5ac9)